### PR TITLE
Ksef iterator

### DIFF
--- a/ksef-api/pom.xml
+++ b/ksef-api/pom.xml
@@ -9,6 +9,11 @@
 
     <artifactId>ksef-api</artifactId>
 
+    <properties>
+        <maven.compiler.source>9</maven.compiler.source>
+        <maven.compiler.target>9</maven.compiler.target>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -28,6 +33,14 @@
                             <Automatic-Module-Name>io.alapierre.ksef.client.model.rest</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -57,6 +70,10 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
 
     </dependencies>

--- a/ksef-api/pom.xml
+++ b/ksef-api/pom.xml
@@ -71,9 +71,17 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/InvoiceQueryResponseAdapter.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/InvoiceQueryResponseAdapter.java
@@ -1,0 +1,36 @@
+package io.alapierre.ksef.client.iterator;
+
+import io.alapierre.ksef.client.model.rest.query.InvoiceQueryResponse;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+@RequiredArgsConstructor
+public class InvoiceQueryResponseAdapter implements PageableResult<InvoiceQueryResponse.InvoiceHeaderList>{
+
+    private final InvoiceQueryResponse response;
+
+    @Override
+    public int getNumberOfElements() {
+        return response.getNumberOfElements();
+    }
+
+    @Override
+    public int getPageSize() {
+        return response.getPageSize();
+    }
+
+    @Override
+    public int getPageOffset() {
+        return response.getPageOffset();
+    }
+
+    @Override
+    public List<InvoiceQueryResponse.InvoiceHeaderList> getItems() {
+        return response.getInvoiceHeaderList();
+    }
+}

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/KsefResultIterator.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/KsefResultIterator.java
@@ -1,0 +1,51 @@
+package io.alapierre.ksef.client.iterator;
+
+import io.alapierre.ksef.client.ApiException;
+import lombok.val;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+public class KsefResultIterator<T> {
+
+    private final Predicate<T> filter;
+
+    public KsefResultIterator(Predicate<T> filter) {
+        this.filter = filter;
+    }
+
+    public KsefResultIterator() {
+        this.filter = t -> true;
+    }
+
+    public List<T> iterate(PageSupplier<PageableResult<T>> supplier) throws ApiException {
+
+        int numberOfPages;
+        int page = 0;
+
+        val values = new LinkedList<T>();
+
+        do {
+
+            val result = supplier.get(page);
+            val numberOfRows = result.getNumberOfElements();
+
+            values.addAll(result.getItems().stream()
+                    .filter(filter)
+                    .collect(Collectors.toList()));
+
+            numberOfPages = (int) Math.ceil((double) numberOfRows / result.getPageSize());
+            page++;
+
+        } while (page < numberOfPages);
+
+        return values;
+    }
+}
+

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/KsefResultStream.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/KsefResultStream.java
@@ -1,0 +1,71 @@
+package io.alapierre.ksef.client.iterator;
+
+import io.alapierre.ksef.client.ApiException;
+
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+public class KsefResultStream<T> {
+
+    private int currentIndex = 0; // element index in currant page
+
+    private int totalIndex = 0; // element index in whole result
+
+    private PageableResult<T> currentPage;
+
+    private int currentPageNumber = 0;
+
+    private int currentPageSize;
+
+    private int totalNumberOfElements;
+
+    private PageSupplier<PageableResult<T>> supplier;
+
+    public Stream<T> stream(PageSupplier<PageableResult<T>> supplier) throws ApiException {
+
+        this.supplier = supplier;
+        nextPage(currentPageNumber);
+
+        if(currentPage.getNumberOfElements() == 0) return Stream.empty();
+
+        return Stream.iterate(next().apply(null), hasNext(), next());
+    }
+
+    private Predicate<T> hasNext() {
+        return t -> totalIndex <= totalNumberOfElements;
+    }
+
+    private UnaryOperator<T> next() {
+        return t -> {
+
+            // Stream.iterate calls next before hasNext
+            // this will protect for IndexOutOfBoundsException
+            if( totalIndex == totalNumberOfElements) {
+                totalIndex++;
+                return null;
+            }
+
+            if(currentIndex >= currentPageSize) {
+                try {
+                    nextPage(++currentPageNumber);
+                } catch (ApiException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            totalIndex++;
+            return currentPage.getItems().get(currentIndex++);
+        };
+    }
+
+    private void nextPage(int pageNumber) throws ApiException {
+        currentPage = supplier.get(pageNumber);
+        currentPageSize = currentPage.getItems().size();
+        totalNumberOfElements = currentPage.getNumberOfElements();
+        currentIndex = 0;
+    }
+}

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/KsefResultStream.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/KsefResultStream.java
@@ -1,6 +1,7 @@
 package io.alapierre.ksef.client.iterator;
 
 import io.alapierre.ksef.client.ApiException;
+import lombok.val;
 
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -25,6 +26,11 @@ public class KsefResultStream<T> {
     private int totalNumberOfElements;
 
     private PageSupplier<PageableResult<T>> supplier;
+
+    public static <T> Stream<T> builder(PageSupplier<PageableResult<T>> supplier) throws ApiException {
+        val in = new KsefResultStream<T>();
+        return in.stream(supplier);
+    }
 
     public Stream<T> stream(PageSupplier<PageableResult<T>> supplier) throws ApiException {
 

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/PageSupplier.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/PageSupplier.java
@@ -1,0 +1,12 @@
+package io.alapierre.ksef.client.iterator;
+
+import io.alapierre.ksef.client.ApiException;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+@FunctionalInterface
+public interface PageSupplier<T> {
+    T get(int page) throws ApiException;
+}

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/PageableResult.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/PageableResult.java
@@ -1,0 +1,17 @@
+package io.alapierre.ksef.client.iterator;
+
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+public interface PageableResult<T> {
+    int getNumberOfElements();
+
+    int getPageSize();
+
+    int getPageOffset();
+
+    List<T> getItems();
+}

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/SessionStatusAdapter.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/iterator/SessionStatusAdapter.java
@@ -1,0 +1,36 @@
+package io.alapierre.ksef.client.iterator;
+
+import io.alapierre.ksef.client.model.rest.auth.SessionStatus;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+@RequiredArgsConstructor
+public class SessionStatusAdapter implements PageableResult<SessionStatus.InvoiceStatusList> {
+
+    private final SessionStatus sessionStatus;
+
+    @Override
+    public int getNumberOfElements() {
+        return sessionStatus.getNumberOfElements();
+    }
+
+    @Override
+    public int getPageSize() {
+        return sessionStatus.getPageSize();
+    }
+
+    @Override
+    public int getPageOffset() {
+        return sessionStatus.getPageOffset();
+    }
+
+    @Override
+    public List<SessionStatus.InvoiceStatusList> getItems() {
+        return sessionStatus.getInvoiceStatusList();
+    }
+}

--- a/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/KsefResultIteratorTest.java
+++ b/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/KsefResultIteratorTest.java
@@ -1,0 +1,43 @@
+package io.alapierre.ksef.client.iterator;
+
+import lombok.val;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+class KsefResultIteratorTest {
+
+    @Test
+    void testIterate() throws Exception {
+
+        val iterator = new KsefResultIterator<Integer>();
+
+        ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 2);
+        val res = iterator.iterate(symulator);
+
+        System.out.println("elements: " + res.size());
+        res.forEach(System.out::println);
+
+        Assertions.assertEquals(11,res.size());
+    }
+
+    @Test
+    void testIterateWithFilter() throws Exception {
+
+        val iterator = new KsefResultIterator<Integer>(integer -> integer != 1);
+
+        ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 2);
+        val res = iterator.iterate(symulator);
+
+        System.out.println("elements: " + res.size());
+        res.forEach(System.out::println);
+
+        Assertions.assertEquals(10,res.size());
+    }
+
+}

--- a/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/KsefResultStreamTest.java
+++ b/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/KsefResultStreamTest.java
@@ -1,0 +1,28 @@
+package io.alapierre.ksef.client.iterator;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+class KsefResultStreamTest {
+
+    @Test
+    void testStream() throws Exception {
+
+        //ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 2);
+        ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3), 2);
+
+        val stream = new KsefResultStream<Integer>();
+        stream.stream(symulator)
+                .forEach(System.out::println);
+
+
+    }
+
+
+}

--- a/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/KsefResultStreamTest.java
+++ b/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/KsefResultStreamTest.java
@@ -4,6 +4,10 @@ import lombok.val;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 /**
  * @author Adrian Lapierre {@literal al@alapierre.io}
@@ -14,13 +18,13 @@ class KsefResultStreamTest {
     @Test
     void testStream() throws Exception {
 
-        //ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 2);
-        ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3), 2);
+        ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 2);
+        //ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3), 2);
 
-        val stream = new KsefResultStream<Integer>();
-        stream.stream(symulator)
-                .forEach(System.out::println);
+        val result = KsefResultStream.builder(symulator)
+                .collect(Collectors.toList());
 
+        assertThat(result, hasItems(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
 
     }
 

--- a/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/ResultSymulator.java
+++ b/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/ResultSymulator.java
@@ -1,0 +1,58 @@
+package io.alapierre.ksef.client.iterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+public class ResultSymulator <T> implements PageSupplier <PageableResult<T>>{
+
+    private final List<List<T>> parts;
+    private final int totalElements;
+    private final int pageSize;
+
+    public ResultSymulator(List<T> elements, int pageSize) {
+        parts = chopped(elements, pageSize);
+        totalElements = elements.size();
+        this.pageSize = pageSize;
+    }
+
+    static <T> List<List<T>> chopped(List<T> list, final int pageSize) {
+        List<List<T>> parts = new ArrayList<>();
+        final int size = list.size();
+        for (int i = 0; i < size; i += pageSize) {
+            parts.add(new ArrayList<>(
+                    list.subList(i, Math.min(size, i + pageSize)))
+            );
+        }
+        return parts;
+    }
+
+
+    @Override
+    public PageableResult<T> get(int page) {
+        return new PageableResult<>() {
+            @Override
+            public int getNumberOfElements() {
+                return totalElements;
+            }
+
+            @Override
+            public int getPageSize() {
+                return pageSize;
+            }
+
+            @Override
+            public int getPageOffset() {
+                return page;
+            }
+
+            @Override
+            public List<T> getItems() {
+                return parts.get(page);
+            }
+        };
+    }
+}

--- a/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/ResultSymulatorTest.java
+++ b/ksef-api/src/test/java/io/alapierre/ksef/client/iterator/ResultSymulatorTest.java
@@ -1,0 +1,27 @@
+package io.alapierre.ksef.client.iterator;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2022.11.19
+ */
+class ResultSymulatorTest {
+
+    @Test
+    void testResults() {
+
+        ResultSymulator<Integer> symulator = new ResultSymulator<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), 2);
+
+        for (int i = 0; i < 6; i++) {
+            val r = symulator.get(i);
+            System.out.printf("page num: %d\n", r.getPageOffset());
+            r.getItems().forEach(System.out::println);
+        }
+
+    }
+
+}

--- a/ksef-sample/src/main/java/io/alapierre/ksef/sample/Main.java
+++ b/ksef-sample/src/main/java/io/alapierre/ksef/sample/Main.java
@@ -13,7 +13,6 @@ import io.alapierre.ksef.client.iterator.InvoiceQueryResponseAdapter;
 import io.alapierre.ksef.client.iterator.KsefResultStream;
 import io.alapierre.ksef.client.model.rest.auth.InitSignedResponse;
 import io.alapierre.ksef.client.model.rest.query.InvoiceQueryRequest;
-import io.alapierre.ksef.client.model.rest.query.InvoiceQueryResponse;
 import io.alapierre.ksef.client.okhttp.OkHttpApiClient;
 import io.alapierre.ksef.client.serializer.gson.GsonJsonSerializer;
 import io.alapierre.ksef.token.facade.KsefTokenFacade;
@@ -130,8 +129,9 @@ public class Main {
                         .build())
                 .build();
 
-        new KsefResultStream<InvoiceQueryResponse.InvoiceHeaderList>().stream(
-                page -> new InvoiceQueryResponseAdapter(zapytaniaApi.invoiceQuery(session.getSessionToken().getToken(), request, 100, page)))
+        val token = session.getSessionToken().getToken();
+        KsefResultStream.builder(
+                page -> new InvoiceQueryResponseAdapter(zapytaniaApi.invoiceQuery(token, request, 100, page)))
                 .forEach(System.out::println);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit-jupiter-api.version}</version>


### PR DESCRIPTION
### Description

KSeF returns list as pageable objects and it will be nice to deal with them like a standard Java streams. This is why `KsefResultStream` class was created. For convenience there are two adapters for `InvoiceQueryResponse` and `SessionStatus`, Thanks for it, effective processing results is easy like one line of code:

```java
KsefResultStream.builder(
                page -> new InvoiceQueryResponseAdapter(zapytaniaApi.invoiceQuery(token, request, 100, page)))
                .forEach(System.out::println);
```