### PR TITLE
Dodanie do clienta obsługi endpointu do pobierania faktur bez uwierzy…

### DIFF
--- a/ksef-api/src/main/java/io/alapierre/ksef/client/api/InterfejsyInteraktywneFakturaApi.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/api/InterfejsyInteraktywneFakturaApi.java
@@ -3,6 +3,7 @@ package io.alapierre.ksef.client.api;
 import io.alapierre.io.IOUtils;
 import io.alapierre.ksef.client.ApiClient;
 import io.alapierre.ksef.client.ApiException;
+import io.alapierre.ksef.client.model.rest.common.*;
 import io.alapierre.ksef.client.model.rest.invoice.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -80,13 +81,22 @@ public class InterfejsyInteraktywneFakturaApi {
         apiClient.getStream(endpoint, token, os);
     }
 
+
+    /**
+     * Pobranie faktury bez uwierzytelniania na podstawie parametrów podanych przez KSeF zgodnie ze specyfikacją endpoint'u
+     * common/Invoice/KSeF. Limit w sekwencji 2 użycia, czas odnowy 60 minut
+     */
+    public void getInvoice(@NotNull InvoiceRequest invoiceRequest, @NotNull OutputStream os) throws ApiException {
+        val endpoint = "common/Invoice/KSeF";
+        apiClient.postStream(endpoint, invoiceRequest, os);
+    }
+
     /**
      * Pobiera UPO dla podanego numeru referencyjnego sesji interaktywnej lub wsadowej. Przekształca wynik zwracany
      * z API ze String na ciąg bajtów zakodowany w UTF-8. Jeśli UPO nie jest dostępne, pole UpoDTO.upo będzie miało
      * wartość null.
      *
      * @param referenceNumber numer referencyjny zakończonej sesji interaktywnej lub wsadowej
-     *
      * @return Odpowiedź z API z UPO w postaci ciągu bajtów (jeśli UPO jest dostępne)
      */
     public UpoDTO getUpo(@NotNull String referenceNumber) throws ApiException {

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/model/rest/common/InvoiceRequest.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/model/rest/common/InvoiceRequest.java
@@ -1,0 +1,21 @@
+package io.alapierre.ksef.client.model.rest.common;
+
+import io.alapierre.ksef.client.model.rest.query.InvoiceQueryResponse;
+import lombok.*;
+
+@Data
+@Builder
+public class InvoiceRequest {
+  private InvoiceDetails invoiceDetails;
+  private String ksefReferenceNumber;
+
+
+  @Data
+  @Builder
+  public static class InvoiceDetails {
+    private String dueValue;
+    private String invoiceOryginalNumber;
+    private InvoiceQueryResponse.SubjectTo subjectTo;
+
+  }
+}

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/model/rest/query/InvoiceQueryResponse.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/model/rest/query/InvoiceQueryResponse.java
@@ -2,6 +2,7 @@ package io.alapierre.ksef.client.model.rest.query;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -38,6 +39,7 @@ public class InvoiceQueryResponse {
 
     @Data
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class SubjectTo{
         private IssuedToIdentifier issuedToIdentifier;
         private IssuedToName issuedToName;
@@ -46,6 +48,7 @@ public class InvoiceQueryResponse {
 
     @Data
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class IssuedToName{
         private String type;
         private String tradeName;
@@ -54,6 +57,7 @@ public class InvoiceQueryResponse {
 
     @Data
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class IssuedToIdentifier{
         private String type;
         private String identifier;

--- a/ksef-api/src/main/java/io/alapierre/ksef/client/model/rest/query/InvoiceQueryResponse.java
+++ b/ksef-api/src/main/java/io/alapierre/ksef/client/model/rest/query/InvoiceQueryResponse.java
@@ -1,5 +1,6 @@
 package io.alapierre.ksef.client.model.rest.query;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.List;
@@ -36,6 +37,7 @@ public class InvoiceQueryResponse {
     }
 
     @Data
+    @AllArgsConstructor
     public static class SubjectTo{
         private IssuedToIdentifier issuedToIdentifier;
         private IssuedToName issuedToName;
@@ -43,6 +45,7 @@ public class InvoiceQueryResponse {
 
 
     @Data
+    @AllArgsConstructor
     public static class IssuedToName{
         private String type;
         private String tradeName;
@@ -50,6 +53,7 @@ public class InvoiceQueryResponse {
     }
 
     @Data
+    @AllArgsConstructor
     public static class IssuedToIdentifier{
         private String type;
         private String identifier;

--- a/ksef-client-jdk11-http-client/src/main/java/io/alapierre/ksef/client/http/HttpApiClient.java
+++ b/ksef-client-jdk11-http-client/src/main/java/io/alapierre/ksef/client/http/HttpApiClient.java
@@ -106,6 +106,25 @@ public class HttpApiClient extends AbstractApiClient {
         throw new IllegalStateException("Not implemented yet");
     }
 
+    @Override
+    public void postStream(@NotNull String endpoint, @NotNull Object body, @NotNull OutputStream os) throws ApiException {
+        HttpRequest request = preparePostRequest(endpoint, Collections.emptyMap(), HttpRequest.BodyPublishers.ofString(serializer.toJson(body)), true);
+
+        try {
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.body() != null) {
+                try (InputStream is = response.body()) {
+                    IOUtils.copy(is, os);
+                }
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new ApiException(e);
+        }
+
+        throw new IllegalStateException("Not implemented yet");
+    }
+
+
     private HttpRequest prepareGetRequest(@NotNull String endpoint, @NotNull Map<String, String> headers) throws ApiException {
         List<String> headersList = prepareHeaders(headers);
         URI uri = prepareURI(endpoint);

--- a/ksef-client-spec/src/main/java/io/alapierre/ksef/client/ApiClient.java
+++ b/ksef-client-spec/src/main/java/io/alapierre/ksef/client/ApiClient.java
@@ -32,4 +32,5 @@ public interface ApiClient {
     <R> Optional<R> postXML(@NotNull String endpoint, @NotNull Object body, @NotNull Class<R> classOfR) throws ApiException;
 
     void getStream(@NotNull String endpoint, @NotNull String token, @NotNull OutputStream os) throws ApiException;
+    void postStream(@NotNull String endpoint, @NotNull Object body, @NotNull OutputStream os) throws ApiException;
 }


### PR DESCRIPTION
### Opis
Celem było dodanie obsługi przez obecnego clienta pobierania faktur bez uwierzytelniania. Dołożyłem metodę bazując na pracy autora biblioteki. Nie narusza to żadnych szczegółów implementacyjnych ani nie wprowadza drastycznych zmian.


### Testowanie

Dodałem metodę w klasie Main modułu "sample", gdzie użytkownik może pobrać dodaną już na serwerze testowym fakturę.
Należy również podać szczegóły dotyczące środowiska, w którym ten PR został opracowany - TESTOWE.