### PR TITLE
#99 Add QR generator and related tests in ksef-qr module

### DIFF
--- a/ksef-qr/pom.xml
+++ b/ksef-qr/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.alapierre.ksef</groupId>
+        <artifactId>ksef-java</artifactId>
+        <version>2.0.23-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>ksef-qr</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.alapierre.ksef</groupId>
+            <artifactId>ksef-client-spec</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.alapierre.ksef</groupId>
+            <artifactId>ksef-api</artifactId>
+            <version>2.0.23-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>core</artifactId>
+            <version>3.5.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>javase</artifactId>
+            <version>3.5.2</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/ksef-qr/src/main/java/io/alapierre/ksef/client/qr/BarcodeGenerationException.java
+++ b/ksef-qr/src/main/java/io/alapierre/ksef/client/qr/BarcodeGenerationException.java
@@ -1,0 +1,23 @@
+package io.alapierre.ksef.client.qr;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2023.12.22
+ */
+public class BarcodeGenerationException extends RuntimeException {
+
+    public BarcodeGenerationException() {
+    }
+
+    public BarcodeGenerationException(String message) {
+        super(message);
+    }
+
+    public BarcodeGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BarcodeGenerationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/ksef-qr/src/main/java/io/alapierre/ksef/client/qr/QrGenerator.java
+++ b/ksef-qr/src/main/java/io/alapierre/ksef/client/qr/QrGenerator.java
@@ -8,13 +8,14 @@ import com.google.zxing.qrcode.QRCodeWriter;
 import io.alapierre.ksef.client.AbstractApiClient.Environment;
 import io.alapierre.ksef.client.ApiException;
 import io.alapierre.ksef.client.api.InterfejsyInteraktywneFakturaApi;
+import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
-import javax.imageio.ImageIO;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -75,19 +76,43 @@ public class QrGenerator {
      * @param width The width of the barcode in pixels.
      * @param height The height of the barcode in pixels.
      * @return The generated barcode as a byte array.
-     * @throws WriterException If the barcode generation fails.
-     * @throws IOException If an error occurs during the image writing.
+     * @throws BarcodeGenerationException if a problem with barcode generation occurs
      */
-    public static byte[] generateBarcode(String barcodeText, int width, int height) throws WriterException, IOException {
+    public static byte[] generateBarcode(@NonNull String barcodeText, int width, int height)  {
+        try {
+            val buf = new ByteArrayOutputStream();
+            writeBarcode(barcodeText, width, height, buf);
+            return buf.toByteArray();
+        } catch (IOException ex) {
+            log.debug(ex.getLocalizedMessage(), ex);
+            throw new BarcodeGenerationException(ex);
+        }
+    }
 
-        QRCodeWriter barcodeWriter = new QRCodeWriter();
-        BitMatrix bitMatrix = barcodeWriter.encode(barcodeText, BarcodeFormat.QR_CODE, width, height);
+    /**
+     * Generates a QR Code barcode image with the given barcode text, width, and height, and writes it to the specified output stream as a PNG.
+     *
+     * @param barcodeText The text to be encoded in the barcode.
+     * @param width The width of the barcode image in pixels.
+     * @param height The height of the barcode image in pixels.
+     * @param out The output stream to write the barcode image to. The OutputStream should be closed by the calling code.
+     * @throws IOException if an I/O error occurs while writing the image to the output stream.
+     * @throws BarcodeGenerationException if a problem with barcode generation occurs
+     */
+    public static void writeBarcode(@NonNull String barcodeText, int width, int height, OutputStream out) throws IOException {
 
-        val img = MatrixToImageWriter.toBufferedImage(bitMatrix);
-        val buf = new ByteArrayOutputStream();
-        ImageIO.write(img, "PNG", buf);
+        if (width <= 0 || height <= 0) {
+            throw new BarcodeGenerationException("width and height must be positive", null);
+        }
 
-        return buf.toByteArray();
+        try {
+            QRCodeWriter barcodeWriter = new QRCodeWriter();
+            BitMatrix bitMatrix = barcodeWriter.encode(barcodeText, BarcodeFormat.QR_CODE, width, height);
+            MatrixToImageWriter.writeToStream(bitMatrix, "PNG", out);
+        } catch (WriterException ex) {
+            log.debug(ex.getLocalizedMessage(), ex);
+            throw new BarcodeGenerationException("Failed to generate barcode: " + ex.getLocalizedMessage());
+        }
     }
 
 }

--- a/ksef-qr/src/main/java/io/alapierre/ksef/client/qr/QrGenerator.java
+++ b/ksef-qr/src/main/java/io/alapierre/ksef/client/qr/QrGenerator.java
@@ -1,0 +1,93 @@
+package io.alapierre.ksef.client.qr;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import io.alapierre.ksef.client.AbstractApiClient.Environment;
+import io.alapierre.ksef.client.ApiException;
+import io.alapierre.ksef.client.api.InterfejsyInteraktywneFakturaApi;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import javax.imageio.ImageIO;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2023.12.21
+ */
+@Slf4j
+public class QrGenerator {
+
+    private QrGenerator() {
+    }
+
+    /**
+     * Generates a verification link for a given environment, KSeF number, and invoice.
+     *
+     * @param environment The environment to generate the link for.
+     * @param ksefNumber The KSEF number.
+     * @param invoice The invoice as a byte array.
+     * @return The verification link.
+     * @throws NoSuchAlgorithmException if the SHA-256 algorithm is not available.
+     * @throws UnsupportedEncodingException if the UTF-8 charset is not supported.
+     */
+    @SneakyThrows
+    public static String verificationLink(Environment environment, String ksefNumber, byte[] invoice) {
+
+        val digest = MessageDigest.getInstance("SHA-256");
+        val sig = Base64.getEncoder().encodeToString(digest.digest(invoice));
+        val encoded = URLEncoder.encode(sig, StandardCharsets.UTF_8);
+
+        return String.format("%s/web/verify/%s/%s", environment.getUrl().replace("/api", ""), ksefNumber, encoded);
+    }
+
+    /**
+     * Returns the verification link for invoice downloaded from KSeF.
+     *
+     * @param api The InterfejsyInteraktywneFakturaApi ksef API.
+     * @param environment The environment to generate the link for.
+     * @param ksefNumber The KSEF invoice number.
+     * @param token The token for authentication.
+     * @return The verification link as a string.
+     * @throws ApiException if an error occurs during the KSeF API call.
+     */
+    public static String verificationLink(InterfejsyInteraktywneFakturaApi api, Environment environment, String ksefNumber, String token) throws ApiException {
+        val out = new ByteArrayOutputStream();
+        api.getInvoice(ksefNumber, token, out);
+        return verificationLink(environment, ksefNumber, out.toByteArray());
+    }
+
+    /**
+     * Generates a QR Code as a byte array for a given barcode text, width, and height.
+     *
+     * @param barcodeText The text that will be encoded in the barcode.
+     * @param width The width of the barcode in pixels.
+     * @param height The height of the barcode in pixels.
+     * @return The generated barcode as a byte array.
+     * @throws WriterException If the barcode generation fails.
+     * @throws IOException If an error occurs during the image writing.
+     */
+    public static byte[] generateBarcode(String barcodeText, int width, int height) throws WriterException, IOException {
+
+        QRCodeWriter barcodeWriter = new QRCodeWriter();
+        BitMatrix bitMatrix = barcodeWriter.encode(barcodeText, BarcodeFormat.QR_CODE, width, height);
+
+        val img = MatrixToImageWriter.toBufferedImage(bitMatrix);
+        val buf = new ByteArrayOutputStream();
+        ImageIO.write(img, "PNG", buf);
+
+        return buf.toByteArray();
+    }
+
+}

--- a/ksef-qr/src/test/java/io/alapierre/ksef/client/qr/QrGeneratorTest.java
+++ b/ksef-qr/src/test/java/io/alapierre/ksef/client/qr/QrGeneratorTest.java
@@ -1,0 +1,48 @@
+package io.alapierre.ksef.client.qr;
+
+import io.alapierre.ksef.client.AbstractApiClient;
+import lombok.val;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * @author Adrian Lapierre {@literal al@alapierre.io}
+ * Copyrights by original author 2023.12.21
+ */
+class QrGeneratorTest {
+
+    @Test
+    void verificationLinkByHash() throws Exception {
+
+        val link = QrGenerator.verificationLink(
+                AbstractApiClient.Environment.TEST,
+                "6891152920-20231221-B3242FB4B54B-DF",
+                Files.readAllBytes(Path.of("src/test/resources/6891152920-20231221-B3242FB4B54B-DF.xml")));
+
+        System.out.println(link);
+
+        Assertions.assertEquals(
+                "https://ksef-test.mf.gov.pl/web/verify/6891152920-20231221-B3242FB4B54B-DF/ssTckvmMFEeA3vp589ExHzTRVhbDksjcFzKoXi4K%2F%2F0%3D",
+                link);
+    }
+
+    @Test
+    void verificationLinkByKsef() {
+    }
+
+    @Test
+    void barcode() throws Exception {
+
+        val barcodeText = "https://ksef-test.mf.gov.pl/web/verify/6891152920-20231221-B3242FB4B54B-DF/ssTckvmMFEeA3vp589ExHzTRVhbDksjcFzKoXi4K%2F%2F0%3D";
+
+        val res = QrGenerator.generateBarcode(barcodeText, 200, 200);
+        File f = File.createTempFile("barcode", ".png");
+        System.out.println(f);
+        Files.write(f.toPath(), res);
+    }
+
+}

--- a/ksef-qr/src/test/resources/6891152920-20231221-B3242FB4B54B-DF.xml
+++ b/ksef-qr/src/test/resources/6891152920-20231221-B3242FB4B54B-DF.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Faktura xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://crd.gov.pl/wzor/2023/06/29/12648/">
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (2)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>2</WariantFormularza>
+        <DataWytworzeniaFa>2023-08-29T12:34:13.7802571Z</DataWytworzeniaFa>
+        <SystemInfo>Samplofaktur</SystemInfo>
+    </Naglowek>
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>6891152920</NIP>
+            <Nazwa>ABC AGD sp. z o. o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Kwiatowa 1</AdresL1>
+        </Adres>
+        <DaneKontaktowe>
+            <Email>example@example.com</Email>
+        </DaneKontaktowe>
+    </Podmiot1>
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>6891152920</NIP>
+            <Nazwa>CeDeE s.c.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ulica i numer</AdresL1>
+        </Adres>
+    </Podmiot2>
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2023-08-31</P_1>
+        <P_2>test-zyba3m-2023-12-21</P_2>
+        <P_13_1>0</P_13_1>
+        <P_14_1>0</P_14_1>
+        <P_13_2>0</P_13_2>
+        <P_14_2>0</P_14_2>
+        <P_13_3>0</P_13_3>
+        <P_14_3>0</P_14_3>
+        <P_13_4>0</P_13_4>
+        <P_14_4>0</P_14_4>
+        <P_13_5>0</P_13_5>
+        <P_13_7>4001.49</P_13_7>
+        <P_15>4001.49</P_15>
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie>
+                <P_19N>1</P_19N>
+            </Zwolnienie>
+            <NoweSrodkiTransportu>
+                <P_22N>1</P_22N>
+            </NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy>
+                <P_PMarzyN>1</P_PMarzyN>
+            </PMarzy>
+        </Adnotacje>
+        <RodzajFaktury>VAT</RodzajFaktury>
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <P_7>Sprzeda? towarów 23%</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2.323</P_8B>
+            <P_9A>234.24</P_9A>
+            <P_11>544.14</P_11>
+            <P_12>zw</P_12>
+        </FaWiersz>
+        <FaWiersz>
+            <NrWierszaFa>2</NrWierszaFa>
+            <P_7>GTU_1</P_7>
+            <P_8A>-</P_8A>
+            <P_8B>2.561</P_8B>
+            <P_9A>1350.00</P_9A>
+            <P_11>3457.35</P_11>
+            <P_12>zw</P_12>
+        </FaWiersz>
+    </Fa>
+</Faktura>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <module>ksef-test-common</module>
         <module>ksef-sample</module>
         <module>ksef-xml-model</module>
+        <module>ksef-qr</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This commit introduces a new QR generator in the ksef-qr module that uses Google ZXing library for QR code generation. The generator includes methods for generating a verification link based on the environment, KSeF number, and invoice data, and for generating the actual QR code as an image. It also includes small unit tests to confirm the functionality.